### PR TITLE
Fix overwrite option for copying directories

### DIFF
--- a/src/lune/builtins/fs/copy.rs
+++ b/src/lune/builtins/fs/copy.rs
@@ -137,8 +137,13 @@ pub async fn copy(
     } else if is_dir {
         let contents = get_contents_at(source.to_path_buf(), options).await?;
 
-        if options.overwrite {
-            fs::remove_dir_all(target).await?;
+        if options.overwrite && target.exists() {
+            let metadata = fs::metadata(target).await?;
+            if metadata.is_file() {
+                fs::remove_file(target).await?;
+            } else if metadata.is_dir() {
+                fs::remove_dir_all(target).await?;
+            }
         }
 
         // FUTURE: Write dirs / files concurrently


### PR DESCRIPTION
Currently, the overwrite option when copying directories only works if the target already exists and is a directory. ``fs::remove_dir_all(target)`` errors if the target does not exist, and currently the overwriting code does not account for that whatever is overwritten might be a file rather than a directory.

```luau
fs = require("@lune/fs")

fs.writeDir("example")
fs.copy("example", "example2", {
    overwrite = true, -- If true, will error if a directory named "example2" doesn't already exist
})
```