### PR TITLE
Serve from other IPs

### DIFF
--- a/src/lune/builtins/net/config.rs
+++ b/src/lune/builtins/net/config.rs
@@ -60,7 +60,6 @@ impl FromLua<'_> for RequestConfig {
     fn from_lua(value: LuaValue, lua: &Lua) -> LuaResult<Self> {
         // If we just got a string we assume its a GET request to a given url
         if let LuaValue::String(s) = value {
-            println!("{:?}", s);
             return Ok(Self {
                 url: s.to_string_lossy().to_string(),
                 method: Method::GET,

--- a/src/lune/builtins/net/mod.rs
+++ b/src/lune/builtins/net/mod.rs
@@ -69,8 +69,6 @@ async fn net_request<'lua>(lua: &'lua Lua, config: RequestConfig) -> LuaResult<L
 where
     'lua: 'static, // FIXME: Get rid of static lifetime bound here
 {
-    println!("net_request config {:?}", config);
-
     // Create and send the request
     let client = NetClient::from_registry(lua);
     let mut request = client.request(config.method, &config.url);
@@ -140,26 +138,19 @@ async fn net_serve<'lua>(
 where
     'lua: 'static, // FIXME: Get rid of static lifetime bound here
 {
-    println!("port {:?}", port);
-
     let sched = lua
         .app_data_ref::<&Scheduler>()
         .expect("Lua struct is missing scheduler");
-
-    println!("config {:?}", config);
 
     let address_pattern = Regex::new(r"(?:.*:\/\/)?([\d\.]+)(?::\d+)?").unwrap();
 
     let address = match &config.address {
         Some(addr) => {
             let caps = address_pattern.captures(addr.to_str()?).unwrap();
-            println!("captures {:?}", &caps);
             caps[1].parse::<Ipv4Addr>()?
         }
         None => Ipv4Addr::new(127, 0, 0, 1),
     };
-
-    println!("address {:?}", address);
 
     let builder = bind_to_addr(address, port)?;
 

--- a/src/lune/builtins/net/server.rs
+++ b/src/lune/builtins/net/server.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, convert::Infallible, net::SocketAddr, sync::Arc};
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
 use hyper::{
     server::{conn::AddrIncoming, Builder},
@@ -20,12 +25,15 @@ use super::{
     websocket::NetWebSocket,
 };
 
-pub(super) fn bind_to_localhost(port: u16) -> LuaResult<Builder<AddrIncoming>> {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+pub(super) fn bind_to_addr(address: Ipv4Addr, port: u16) -> LuaResult<Builder<AddrIncoming>> {
+    let addr = SocketAddr::from((address, port));
+
+    println!("attempting to bind to {:?}", addr);
+
     match Server::try_bind(&addr) {
         Ok(b) => Ok(b),
         Err(e) => Err(LuaError::external(format!(
-            "Failed to bind to localhost on port {port}\n{}",
+            "Failed to bind to {addr}\n{}",
             e.to_string()
                 .replace("error creating server listener: ", "> ")
         ))),

--- a/src/lune/builtins/net/server.rs
+++ b/src/lune/builtins/net/server.rs
@@ -28,8 +28,6 @@ use super::{
 pub(super) fn bind_to_addr(address: Ipv4Addr, port: u16) -> LuaResult<Builder<AddrIncoming>> {
     let addr = SocketAddr::from((address, port));
 
-    println!("attempting to bind to {:?}", addr);
-
     match Server::try_bind(&addr) {
         Ok(b) => Ok(b),
         Err(e) => Err(LuaError::external(format!(

--- a/tests/net/serve/requests.luau
+++ b/tests/net/serve/requests.luau
@@ -5,6 +5,7 @@ local task = require("@lune/task")
 
 local PORT = 8080
 local URL = `http://127.0.0.1:{PORT}`
+local URL_EXTERNAL = `http://0.0.0.0:{PORT}`
 local RESPONSE = "Hello, lune!"
 
 -- Serve should not block the thread from continuing
@@ -77,3 +78,15 @@ assert(
 		or string.find(message, "shut down"),
 	"The error message for calling stop twice on the net serve handle should be descriptive"
 )
+
+-- Serve should be able to bind to other IP addresses
+handle = net.serve(URL_EXTERNAL, function(request)
+	assert(request.path == "/some/path")
+	assert(request.query.key == "param2")
+	assert(request.query.key2 == "param3")
+	return RESPONSE
+end)
+
+-- And any requests to that IP should succeed
+response = net.request(URL_EXTERNAL .. "/some/path?key=param1&key=param2&key2=param3").body
+assert(response == RESPONSE, "Invalid response from server")

--- a/tests/net/serve/requests.luau
+++ b/tests/net/serve/requests.luau
@@ -96,3 +96,15 @@ local response3 = net.request(`{URL_EXTERNAL}:{PORT}`).body
 assert(response3 ~= nil, "Invalid response from server")
 
 handle2.stop()
+
+-- Attempting to serve with a malformed IP address should throw an error
+local success3 = pcall(function()
+	net.serve(8080, {
+		address = "a.b.c.d",
+		handleRequest = function()
+			return RESPONSE
+		end,
+	})
+end)
+
+assert(not success3, "Server was created with malformed address")

--- a/tests/net/serve/requests.luau
+++ b/tests/net/serve/requests.luau
@@ -5,12 +5,12 @@ local task = require("@lune/task")
 
 local PORT = 8080
 local URL = `http://127.0.0.1:{PORT}`
-local URL_EXTERNAL = `http://0.0.0.0:{PORT}`
+local URL_EXTERNAL = `http://0.0.0.0`
 local RESPONSE = "Hello, lune!"
 
 -- A server should never be running before testing
 local isRunning = pcall(net.request, URL)
-assert(not isRunning, `A server is already running at {URL}`)
+assert(not isRunning, `a server is already running at {URL}`)
 
 -- Serve should not block the thread from continuing
 
@@ -21,8 +21,6 @@ local thread = task.delay(1, function()
 end)
 
 local handle = net.serve(PORT, function(request)
-	-- print("Request:", request)
-	-- print("Responding with", RESPONSE)
 	assert(request.path == "/some/path")
 	assert(request.query.key == "param2")
 	assert(request.query.key2 == "param3")
@@ -84,13 +82,15 @@ assert(
 )
 
 -- Serve should be able to bind to other IP addresses
-handle = net.serve(URL_EXTERNAL, function(request)
-	assert(request.path == "/some/path")
-	assert(request.query.key == "param2")
-	assert(request.query.key2 == "param3")
-	return RESPONSE
-end)
+local handle2 = net.serve(PORT, {
+	address = URL_EXTERNAL,
+	handleRequest = function(request)
+		return `Response from {URL_EXTERNAL}:{PORT}`
+	end,
+})
 
 -- And any requests to that IP should succeed
-response = net.request(URL_EXTERNAL .. "/some/path?key=param1&key=param2&key2=param3").body
-assert(response == RESPONSE, "Invalid response from server")
+local response3 = net.request(`{URL_EXTERNAL}:{PORT}`).body
+assert(response3 ~= nil, "Invalid response from server")
+
+handle2.stop()

--- a/tests/net/serve/requests.luau
+++ b/tests/net/serve/requests.luau
@@ -21,6 +21,8 @@ local thread = task.delay(1, function()
 end)
 
 local handle = net.serve(PORT, function(request)
+	-- print("Request:", request)
+	-- print("Responding with", RESPONSE)
 	assert(request.path == "/some/path")
 	assert(request.query.key == "param2")
 	assert(request.query.key2 == "param3")

--- a/tests/net/serve/requests.luau
+++ b/tests/net/serve/requests.luau
@@ -8,6 +8,10 @@ local URL = `http://127.0.0.1:{PORT}`
 local URL_EXTERNAL = `http://0.0.0.0:{PORT}`
 local RESPONSE = "Hello, lune!"
 
+-- A server should never be running before testing
+local isRunning = pcall(net.request, URL)
+assert(not isRunning, `A server is already running at {URL}`)
+
 -- Serve should not block the thread from continuing
 
 local thread = task.delay(1, function()

--- a/tests/net/serve/requests.luau
+++ b/tests/net/serve/requests.luau
@@ -108,3 +108,6 @@ local success3 = pcall(function()
 end)
 
 assert(not success3, "Server was created with malformed address")
+
+-- We have to manually exit so Windows CI doesn't get stuck forever
+process.exit(0)


### PR DESCRIPTION
This PR introduces a new `address` property to `net.serve` to change which IP address to serve off of

Usage:
```lua
-- Continues to function like normal and binds to loopback interface
net.serve(8080, function(request)
  -- ...
end)

-- Use the config object to serve on a different IP
net.serve(8080, {
  address = "http://0.0.0.0",
  handleRequest = function(request)
    -- ...
  end,
})
```

Resolves #120 