### PR TITLE
Add a timeout to CI runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
           - name: macOS x86_64
             runner-os: macos-latest
             cargo-target: x86_64-apple-darwin
-
+    timeout-minutes: 10
     name: CI - ${{ matrix.name }}
     runs-on: ${{ matrix.runner-os }}
     steps:


### PR DESCRIPTION
This way when Windows CI hangs forever it will at least cancel out much earlier