### PR TITLE
Fix fs.copy not working with empty dirs

### DIFF
--- a/src/lune/builtins/fs/copy.rs
+++ b/src/lune/builtins/fs/copy.rs
@@ -150,6 +150,8 @@ pub async fn copy(
             }
         }
 
+        fs::create_dir_all(target).await?;
+
         // FUTURE: Write dirs / files concurrently
         // to potentially speed these operations up
         for (_, dir) in &contents.dirs {


### PR DESCRIPTION
Simple fix for #154 