### PR TITLE
Support JSON5 deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "serde_json5",
  "serde_yaml",
  "thiserror",
  "tokio",
@@ -1393,6 +1394,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project"
@@ -1993,6 +2039,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json5"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a6b754515e1a7bd79fc2edeaecee526fc80cb3a918607e5ca149225a3a9586"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,6 +2108,17 @@ name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -2567,6 +2635,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ async-compression = { version = "0.4", features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_json5 = { version = "0.1.0" }
 serde_yaml = "0.9"
 toml = { version = "0.8", features = ["preserve_order"] }
 

--- a/src/lune/builtins/net/mod.rs
+++ b/src/lune/builtins/net/mod.rs
@@ -63,7 +63,8 @@ fn net_json_encode<'lua>(
 }
 
 fn net_json_decode<'lua>(lua: &'lua Lua, json: LuaString<'lua>) -> LuaResult<LuaValue<'lua>> {
-    EncodeDecodeConfig::from(EncodeDecodeFormat::Json).deserialize_from_string(lua, json)
+    // NOTE: JSON is valid JSON5, so we use the JSON5 decoder here
+    EncodeDecodeConfig::from(EncodeDecodeFormat::Json5).deserialize_from_string(lua, json)
 }
 
 async fn net_request<'lua>(lua: &'lua Lua, config: RequestConfig) -> LuaResult<LuaTable<'lua>>

--- a/tests/serde/json/decode.luau
+++ b/tests/serde/json/decode.luau
@@ -51,3 +51,14 @@ assert(
 		productCount
 	)
 )
+
+local json5Response = net.request("https://raw.githubusercontent.com/chromium/chromium/feb3c9f670515edf9a88f185301cbd7794ee3e52/third_party/blink/renderer/platform/runtime_enabled_features.json5")
+
+assert(json5Response.ok, "Failed to fetch JSON5 file contents")
+assert(#json5Response.body > 0, "Received an empty response body for JSON5 file")
+
+local decodedJson5 = serde.decode("json5", json5Response.body)
+
+assert(type(decodedJson5.parameters) == "table", "Parameters was not a table")
+assert(#decodedJson5.data == 556, "Data table wasn't expected size") -- Number is hardcoded, since the commit hash is pinned
+

--- a/types/net.luau
+++ b/types/net.luau
@@ -294,6 +294,19 @@ end
 	@within Net
 	@tag must_use
 
+	Decodes the given JSON5 string into a lua value.
+
+	@param encoded The JSON5 string to decode
+	@return The decoded lua value
+]=]
+function net.json5Decode(encoded: string): any
+	return nil :: any
+end
+
+--[=[
+	@within Net
+	@tag must_use
+
 	Encodes the given string using URL encoding.
 
 	@param s The string to encode

--- a/types/serde.luau
+++ b/types/serde.luau
@@ -1,4 +1,4 @@
-export type EncodeDecodeFormat = "json" | "yaml" | "toml"
+export type EncodeDecodeFormat = "json" | "json5" | "yaml" | "toml"
 
 export type CompressDecompressFormat = "brotli" | "gzip" | "lz4" | "zlib"
 
@@ -18,6 +18,7 @@ export type CompressDecompressFormat = "brotli" | "gzip" | "lz4" | "zlib"
 
 	-- Parse different file formats into lua tables
 	local someJson = serde.decode("json", fs.readFile("myFile.json"))
+	local someJson5 = serde.decode("json5", fs.readFile("myFile.json5"))
 	local someToml = serde.decode("toml", fs.readFile("myFile.toml"))
 	local someYaml = serde.decode("yaml", fs.readFile("myFile.yaml"))
 
@@ -60,11 +61,12 @@ end
 
 	Currently supported formats:
 
-	| Name   | Learn More           |
-	|:-------|:---------------------|
-	| `json` | https://www.json.org |
-	| `yaml` | https://yaml.org     |
-	| `toml` | https://toml.io      |
+	| Name    | Learn More           |
+	|:--------|:---------------------|
+	| `json`  | https://www.json.org |
+	| `json5` | https://json5.org    |
+	| `yaml`  | https://yaml.org     |
+	| `toml`  | https://toml.io      |
 
 	@param format The format to use
 	@param encoded The string to decode


### PR DESCRIPTION
This PR implements JSON5 deserialization (and serialization too, for the sake of completeness) for the `serde` and `net` builtin libraries.

## TODO:
- [x] Implementation
  - [x] `@lune/serde`
    - [x] `encode`
    - [x] `decode`
  - [x] `@lune/net`
    - [x] `jsonDecode`
- [x] Tests & Documentation
  - [x] Document new `json5` union variant
  - [x] Include tests 

Closes #141.