### PR TITLE
(do not merge) add test to check that modules are cached correctly

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -95,6 +95,7 @@ create_tests! {
     require_nested: "require/tests/nested",
     require_parents: "require/tests/parents",
     require_siblings: "require/tests/siblings",
+    require_state: "require/tests/state",
 
     global_g_table: "globals/_G",
     global_version: "globals/_VERSION",

--- a/tests/require/tests/state.luau
+++ b/tests/require/tests/state.luau
@@ -3,14 +3,14 @@
 local state_module = require("./state_module")
 
 -- we confirm that without anything happening, the initial value is what we ecpect
-assert(state_module.state == 10)
 assert(_state_test_global == 10)
+assert(state_module.state == 10)
 
 -- this second file also requires state_module and calls a function that changes both the local state and the global to 11
 require("./state_second")
 
--- with correct module caching, we should see the change done in state_secone reflected here
-assert(state_module.state == 11)
 -- if this also fails then there is either a problem with globals, or state_second is not doing what we expect it to
 assert(_state_test_global == 11)
+-- with correct module caching, we should see the change done in state_secone reflected here
+assert(state_module.state == 11)
 

--- a/tests/require/tests/state.luau
+++ b/tests/require/tests/state.luau
@@ -1,0 +1,16 @@
+-- the idea of this test is that state_module stores some state in one of its local variable
+-- we also set a global in the module to ensure the change we would have expected happens
+local state_module = require("./state_module")
+
+-- we confirm that without anything happening, the initial value is what we ecpect
+assert(state_module.state == 10)
+assert(_state_test_global == 10)
+
+-- this second file also requires state_module and calls a function that changes both the local state and the global to 11
+require("./state_second")
+
+-- with correct module caching, we should see the change done in state_secone reflected here
+assert(state_module.state == 11)
+-- if this also fails then there is either a problem with globals, or state_second is not doing what we expect it to
+assert(_state_test_global == 11)
+

--- a/tests/require/tests/state_module.luau
+++ b/tests/require/tests/state_module.luau
@@ -1,0 +1,11 @@
+local M = {}
+
+M.state = 10
+_state_test_global = 10
+
+function M.set_state(n: number)
+    M.state = n
+    _state_test_global = n
+end
+
+return M

--- a/tests/require/tests/state_second.luau
+++ b/tests/require/tests/state_second.luau
@@ -1,0 +1,5 @@
+local state_module = require("./state_module")
+
+state_module.set_state(11)
+
+return {}


### PR DESCRIPTION
I added a simple test to confirm the issue with module caching reported in #138.

I tried to comment the test to explain what it is doing, hopefully it's enough.

When I run the tests locally, only the assertion on line 15 of `state.luau` hits. Indicating that the global was set correctly, but the module was not cached correctly.

I only have the global there to prove that `state_second.luau` is actually doing something, when this bug gets fixed, the global can be removed and querying the local state should be sufficient