### PR TITLE
Use correct tuple ordering in resolve_paths 

### DIFF
--- a/src/lune/globals/require/context.rs
+++ b/src/lune/globals/require/context.rs
@@ -70,7 +70,7 @@ impl RequireContext {
             CWD.join(&rel_path)
         };
 
-        Ok((rel_path, abs_path))
+        Ok((abs_path, rel_path))
     }
 
     /**

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -95,6 +95,7 @@ create_tests! {
     require_nested: "require/tests/nested",
     require_parents: "require/tests/parents",
     require_siblings: "require/tests/siblings",
+    require_state: "require/tests/state",
 
     global_g_table: "globals/_G",
     global_version: "globals/_VERSION",

--- a/tests/require/tests/state.luau
+++ b/tests/require/tests/state.luau
@@ -2,7 +2,7 @@
 -- variable
 local state_module = require("./state_module")
 
--- we confirm that without anything happening, the initial value is what we ecpect
+-- we confirm that without anything happening, the initial value is what we expect
 assert(state_module.state == 10)
 
 -- this second file also requires state_module and calls a function that changes the local

--- a/tests/require/tests/state.luau
+++ b/tests/require/tests/state.luau
@@ -3,14 +3,14 @@
 local state_module = require("./state_module")
 
 -- we confirm that without anything happening, the initial value is what we ecpect
-assert(state_module.state == 10)
 assert(_state_test_global == 10)
+assert(state_module.state == 10)
 
 -- this second file also requires state_module and calls a function that changes both the local state and the global to 11
 require("./state_second")
 
--- with correct module caching, we should see the change done in state_secone reflected here
-assert(state_module.state == 11)
 -- if this also fails then there is either a problem with globals, or state_second is not doing what we expect it to
 assert(_state_test_global == 11)
+-- with correct module caching, we should see the change done in state_secone reflected here
+assert(state_module.state == 11)
 

--- a/tests/require/tests/state.luau
+++ b/tests/require/tests/state.luau
@@ -1,0 +1,16 @@
+-- the idea of this test is that state_module stores some state in one of its local variable
+-- we also set a global in the module to ensure the change we would have expected happens
+local state_module = require("./state_module")
+
+-- we confirm that without anything happening, the initial value is what we ecpect
+assert(state_module.state == 10)
+assert(_state_test_global == 10)
+
+-- this second file also requires state_module and calls a function that changes both the local state and the global to 11
+require("./state_second")
+
+-- with correct module caching, we should see the change done in state_secone reflected here
+assert(state_module.state == 11)
+-- if this also fails then there is either a problem with globals, or state_second is not doing what we expect it to
+assert(_state_test_global == 11)
+

--- a/tests/require/tests/state.luau
+++ b/tests/require/tests/state.luau
@@ -1,16 +1,14 @@
--- the idea of this test is that state_module stores some state in one of its local variable
--- we also set a global in the module to ensure the change we would have expected happens
+-- the idea of this test is that state_module stores some state in one of its local
+-- variable
 local state_module = require("./state_module")
 
 -- we confirm that without anything happening, the initial value is what we ecpect
-assert(_state_test_global == 10)
 assert(state_module.state == 10)
 
--- this second file also requires state_module and calls a function that changes both the local state and the global to 11
+-- this second file also requires state_module and calls a function that changes the local
+-- state to 11
 require("./state_second")
 
--- if this also fails then there is either a problem with globals, or state_second is not doing what we expect it to
-assert(_state_test_global == 11)
--- with correct module caching, we should see the change done in state_secone reflected here
+-- with correct module caching, we should see the change done in state_secone reflected
+-- here
 assert(state_module.state == 11)
-

--- a/tests/require/tests/state_module.luau
+++ b/tests/require/tests/state_module.luau
@@ -1,11 +1,9 @@
 local M = {}
 
 M.state = 10
-_state_test_global = 10
 
 function M.set_state(n: number)
     M.state = n
-    _state_test_global = n
 end
 
 return M

--- a/tests/require/tests/state_module.luau
+++ b/tests/require/tests/state_module.luau
@@ -1,0 +1,11 @@
+local M = {}
+
+M.state = 10
+_state_test_global = 10
+
+function M.set_state(n: number)
+    M.state = n
+    _state_test_global = n
+end
+
+return M

--- a/tests/require/tests/state_second.luau
+++ b/tests/require/tests/state_second.luau
@@ -1,0 +1,5 @@
+local state_module = require("./state_module")
+
+state_module.set_state(11)
+
+return {}


### PR DESCRIPTION
After noticing that the test in #170 failed, and after some inspection in a debugger, I discovered some incorrectness around the `RequireContext::resolve_paths` method. This method returns a tuple `(rel_path, abs_path)`, but the caller seems to expect `(abs_path, rel_path)`:

https://github.com/lune-org/lune/blob/94ba331ed0025b45b687a401e06521afbc4ff109/src/lune/globals/require/context.rs#L56-L74

https://github.com/lune-org/lune/blob/94ba331ed0025b45b687a401e06521afbc4ff109/src/lune/globals/require/path.rs#L16

This PR closes #138 by swapping the order of the tuple fields in `RequireContext::resolve_paths` to match the rest of the code.