### PR TITLE
Remove Luau Override from `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,5 @@
 * text=auto
 
-# Temporarily highlight luau as normal lua files
-# until we get native linguist support for Luau
-*.luau linguist-language=Lua
-
 # Ensure all lua files use LF
 *.lua  eol=lf
 *.luau eol=lf


### PR DESCRIPTION
GitHub now supports Luau, super happy to finally not have this in the gitattributes anymore!