### PR TITLE
Add level option to `serde.compress`

### DIFF
--- a/crates/lune-std-serde/src/lib.rs
+++ b/crates/lune-std-serde/src/lib.rs
@@ -46,9 +46,9 @@ fn serde_decode(lua: &Lua, (format, bs): (EncodeDecodeFormat, BString)) -> LuaRe
 
 async fn serde_compress(
     lua: &Lua,
-    (format, bs): (CompressDecompressFormat, BString),
+    (format, bs, level): (CompressDecompressFormat, BString, Option<i32>),
 ) -> LuaResult<LuaString> {
-    let bytes = compress(bs, format).await?;
+    let bytes = compress(bs, format, level).await?;
     lua.create_string(bytes)
 }
 

--- a/types/serde.luau
+++ b/types/serde.luau
@@ -136,9 +136,10 @@ end
 
 	@param format The format to use
 	@param s The string to compress
+	@param level The compression level to use, clamped to the format's limits. The best compression level is used by default
 	@return The compressed string
 ]=]
-function serde.compress(format: CompressDecompressFormat, s: buffer | string): string
+function serde.compress(format: CompressDecompressFormat, s: buffer | string, level: number?): string
 	return nil :: any
 end
 


### PR DESCRIPTION
Closes #223 

Adds a new, optional third parameter to `serde.compress`, which allows the user to select a custom compression level. Defaults to the existing "Best" level if a level isn't provided.