### PR TITLE
Allow scripts located in ./scripts to be detected by lune

### DIFF
--- a/crates/lune/src/cli/utils/files.rs
+++ b/crates/lune/src/cli/utils/files.rs
@@ -127,10 +127,11 @@ pub fn discover_script_path(path: impl AsRef<str>, in_home_dir: bool) -> Result<
 
 /**
     Discovers a script file path based on a given script name, and tries to
-    find scripts in `lune` and `.lune` folders if one was not directly found.
+    find scripts in `lune`, `.lune` and `scripts` folders if one was not
+    directly found.
 
-    Note that looking in `lune` and `.lune` folders is automatically
-    disabled if the given script name is an absolute path.
+    Note that looking in `lune`, `scripts` and `.lune` folders is
+    automatically disabled if the given script name is an absolute path.
 
     Behavior is otherwise exactly the same as for `discover_script_file_path`.
 */
@@ -148,6 +149,7 @@ pub fn discover_script_path_including_lune_dirs(path: &str) -> Result<PathBuf> {
             // directories + the home directory for the current user
             let res = discover_script_path(format!("lune{MAIN_SEPARATOR}{path}"), false)
                 .or_else(|_| discover_script_path(format!(".lune{MAIN_SEPARATOR}{path}"), false))
+                .or_else(|_| discover_script_path(format!("scripts{MAIN_SEPARATOR}{path}"), false))
                 .or_else(|_| discover_script_path(format!("lune{MAIN_SEPARATOR}{path}"), true))
                 .or_else(|_| discover_script_path(format!(".lune{MAIN_SEPARATOR}{path}"), true));
 

--- a/crates/lune/src/cli/utils/listing.rs
+++ b/crates/lune/src/cli/utils/listing.rs
@@ -23,6 +23,9 @@ pub async fn find_lune_scripts(in_home_dir: bool) -> Result<Vec<(String, String)
     if lune_dir.is_err() {
         lune_dir = fs::read_dir(base_path.join(".lune")).await;
     }
+    if lune_dir.is_err() && !in_home_dir {
+        lune_dir = fs::read_dir(base_path.join("scripts")).await;
+    }
     match lune_dir {
         Ok(mut dir) => {
             let mut files = Vec::new();


### PR DESCRIPTION
Closes #225 

Allows scripts located in `./scripts` to be detected by both `lune run` and `lune list`. [Documentation will need to be updated to reflect this](https://lune-org.github.io/docs/getting-started/3-command-line-usage)

If this change is accepted the priority will be as follows:

```diff
  ./lune
  ./.lune
+ ./scripts
  ~/lune
  ~/.lune
```

Discussion may be required concerning the possibility that a user's home scripts could potentially be overridden by a script in `scripts` due to this change.