### PR TITLE
Add missing vector methods

### DIFF
--- a/crates/lune-roblox/src/datatypes/types/vector2.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector2.rs
@@ -83,6 +83,7 @@ impl LuaUserData for Vector2 {
         methods.add_method("Min", |_, this, rhs: LuaUserDataRef<Vector2>| {
             Ok(Vector2(this.0.min(rhs.0)))
         });
+        methods.add_method("Abs", |_, this, ()| Ok(Vector2(this.0.abs())));
         // Metamethods
         methods.add_meta_method(LuaMetaMethod::Eq, userdata_impl_eq);
         methods.add_meta_method(LuaMetaMethod::ToString, userdata_impl_to_string);

--- a/crates/lune-roblox/src/datatypes/types/vector2.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector2.rs
@@ -85,6 +85,7 @@ impl LuaUserData for Vector2 {
         });
         methods.add_method("Abs", |_, this, ()| Ok(Vector2(this.0.abs())));
         methods.add_method("Ceil", |_, this, ()| Ok(Vector2(this.0.ceil())));
+        methods.add_method("Floor", |_, this, ()| Ok(Vector2(this.0.floor())));
         // Metamethods
         methods.add_meta_method(LuaMetaMethod::Eq, userdata_impl_eq);
         methods.add_meta_method(LuaMetaMethod::ToString, userdata_impl_to_string);

--- a/crates/lune-roblox/src/datatypes/types/vector2.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector2.rs
@@ -86,6 +86,7 @@ impl LuaUserData for Vector2 {
         methods.add_method("Abs", |_, this, ()| Ok(Vector2(this.0.abs())));
         methods.add_method("Ceil", |_, this, ()| Ok(Vector2(this.0.ceil())));
         methods.add_method("Floor", |_, this, ()| Ok(Vector2(this.0.floor())));
+        methods.add_method("Sign", |_, this, ()| Ok(Vector2(this.0.signum())));
         // Metamethods
         methods.add_meta_method(LuaMetaMethod::Eq, userdata_impl_eq);
         methods.add_meta_method(LuaMetaMethod::ToString, userdata_impl_to_string);

--- a/crates/lune-roblox/src/datatypes/types/vector2.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector2.rs
@@ -52,6 +52,9 @@ impl LuaUserData for Vector2 {
 
     fn add_methods<'lua, M: LuaUserDataMethods<'lua, Self>>(methods: &mut M) {
         // Methods
+        methods.add_method("Angle", |_, this, rhs: LuaUserDataRef<Vector2>| {
+            Ok(this.0.angle_between(rhs.0))
+        });
         methods.add_method("Cross", |_, this, rhs: LuaUserDataRef<Vector2>| {
             let this_v3 = Vec3::new(this.0.x, this.0.y, 0f32);
             let rhs_v3 = Vec3::new(rhs.0.x, rhs.0.y, 0f32);

--- a/crates/lune-roblox/src/datatypes/types/vector2.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector2.rs
@@ -64,6 +64,14 @@ impl LuaUserData for Vector2 {
             Ok(this.0.dot(rhs.0))
         });
         methods.add_method(
+            "FuzzyEq",
+            |_, this, (rhs, epsilon): (LuaUserDataRef<Vector2>, f32)| {
+                let eq_x = (rhs.0.x - this.0.x).abs() <= epsilon;
+                let eq_y = (rhs.0.y - this.0.y).abs() <= epsilon;
+                Ok(eq_x && eq_y)
+            },
+        );
+        methods.add_method(
             "Lerp",
             |_, this, (rhs, alpha): (LuaUserDataRef<Vector2>, f32)| {
                 Ok(Vector2(this.0.lerp(rhs.0, alpha)))

--- a/crates/lune-roblox/src/datatypes/types/vector2.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector2.rs
@@ -84,6 +84,7 @@ impl LuaUserData for Vector2 {
             Ok(Vector2(this.0.min(rhs.0)))
         });
         methods.add_method("Abs", |_, this, ()| Ok(Vector2(this.0.abs())));
+        methods.add_method("Ceil", |_, this, ()| Ok(Vector2(this.0.ceil())));
         // Metamethods
         methods.add_meta_method(LuaMetaMethod::Eq, userdata_impl_eq);
         methods.add_meta_method(LuaMetaMethod::ToString, userdata_impl_to_string);

--- a/crates/lune-roblox/src/datatypes/types/vector3.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector3.rs
@@ -136,6 +136,7 @@ impl LuaUserData for Vector3 {
         methods.add_method("Abs", |_, this, ()| Ok(Vector3(this.0.abs())));
         methods.add_method("Ceil", |_, this, ()| Ok(Vector3(this.0.ceil())));
         methods.add_method("Floor", |_, this, ()| Ok(Vector3(this.0.floor())));
+        methods.add_method("Sign", |_, this, ()| Ok(Vector3(this.0.signum())));
         // Metamethods
         methods.add_meta_method(LuaMetaMethod::Eq, userdata_impl_eq);
         methods.add_meta_method(LuaMetaMethod::ToString, userdata_impl_to_string);

--- a/crates/lune-roblox/src/datatypes/types/vector3.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector3.rs
@@ -133,6 +133,7 @@ impl LuaUserData for Vector3 {
         methods.add_method("Min", |_, this, rhs: LuaUserDataRef<Vector3>| {
             Ok(Vector3(this.0.min(rhs.0)))
         });
+        methods.add_method("Abs", |_, this, ()| Ok(Vector3(this.0.abs())));
         // Metamethods
         methods.add_meta_method(LuaMetaMethod::Eq, userdata_impl_eq);
         methods.add_meta_method(LuaMetaMethod::ToString, userdata_impl_to_string);

--- a/crates/lune-roblox/src/datatypes/types/vector3.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector3.rs
@@ -134,6 +134,7 @@ impl LuaUserData for Vector3 {
             Ok(Vector3(this.0.min(rhs.0)))
         });
         methods.add_method("Abs", |_, this, ()| Ok(Vector3(this.0.abs())));
+        methods.add_method("Ceil", |_, this, ()| Ok(Vector3(this.0.ceil())));
         // Metamethods
         methods.add_meta_method(LuaMetaMethod::Eq, userdata_impl_eq);
         methods.add_meta_method(LuaMetaMethod::ToString, userdata_impl_to_string);

--- a/crates/lune-roblox/src/datatypes/types/vector3.rs
+++ b/crates/lune-roblox/src/datatypes/types/vector3.rs
@@ -135,6 +135,7 @@ impl LuaUserData for Vector3 {
         });
         methods.add_method("Abs", |_, this, ()| Ok(Vector3(this.0.abs())));
         methods.add_method("Ceil", |_, this, ()| Ok(Vector3(this.0.ceil())));
+        methods.add_method("Floor", |_, this, ()| Ok(Vector3(this.0.floor())));
         // Metamethods
         methods.add_meta_method(LuaMetaMethod::Eq, userdata_impl_eq);
         methods.add_meta_method(LuaMetaMethod::ToString, userdata_impl_to_string);

--- a/tests/roblox/datatypes/Vector2.luau
+++ b/tests/roblox/datatypes/Vector2.luau
@@ -49,7 +49,6 @@ assert(Vector2.new(-1.9, 2.1):Ceil() == Vector2.new(-1, 3))
 assert(Vector2.new(-1.1, 2.99):Floor() == Vector2.new(-2, 2))
 
 assert(Vector2.new(1, 2):FuzzyEq(Vector2.new(1 - 1e-6, 2 + 1e-6)))
-assert(Vector2.new(1, 2):Angle(Vector2.new(3, 4)))
 
 local angle = Vector2.new(1, 1):Angle(Vector2.new(-1, 1))
 assert(math.abs(angle - (math.pi / 2)) < 1e-5)

--- a/tests/roblox/datatypes/Vector2.luau
+++ b/tests/roblox/datatypes/Vector2.luau
@@ -48,7 +48,8 @@ assert(Vector2.new(-1.7, 2):Sign() == Vector2.new(-1, 1))
 assert(Vector2.new(-1.9, 2.1):Ceil() == Vector2.new(-1, 3))
 assert(Vector2.new(-1.1, 2.99):Floor() == Vector2.new(-2, 2))
 
-assert(Vector2.new(1, 2):FuzzyEq(Vector2.new(1 - 1e-6, 2 + 1e-6)))
+assert(Vector2.new(1, 2):FuzzyEq(Vector2.new(1 - 1e-6, 2 + 1e-6), 1e-5))
+assert(not Vector2.new(1, 2):FuzzyEq(Vector2.new(1.2, 2), 0.1))
 
 local angle = Vector2.new(1, 1):Angle(Vector2.new(-1, 1))
 assert(math.abs(angle - (math.pi / 2)) < 1e-5)

--- a/tests/roblox/datatypes/Vector2.luau
+++ b/tests/roblox/datatypes/Vector2.luau
@@ -42,4 +42,14 @@ assert(Vector2.new(2, 4) / 2 == Vector2.new(1, 2))
 assert(Vector2.new(7, 15) // Vector2.new(3, 7) == Vector2.new(2, 2))
 assert(Vector2.new(3, 7) // 2 == Vector2.new(1, 3))
 
--- TODO: Vector math
+-- Vector math methods
+assert(Vector2.new(-1, -2):Abs() == Vector2.new(1, 2))
+assert(Vector2.new(-1.7, 2):Sign() == Vector2.new(-1, 1))
+assert(Vector2.new(-1.9, 2.1):Ceil() == Vector2.new(-1, 3))
+assert(Vector2.new(-1.1, 2.99):Floor() == Vector2.new(-2, 2))
+
+assert(Vector2.new(1, 2):FuzzyEq(Vector2.new(1 - 1e-6, 2 + 1e-6)))
+assert(Vector2.new(1, 2):Angle(Vector2.new(3, 4)))
+
+local angle = Vector2.new(1, 1):Angle(Vector2.new(-1, 1))
+assert(math.abs(angle - (math.pi / 2)) < 1e-5)

--- a/tests/roblox/datatypes/Vector3.luau
+++ b/tests/roblox/datatypes/Vector3.luau
@@ -45,4 +45,8 @@ assert(Vector3.new(2, 4, 8) / 2 == Vector3.new(1, 2, 4))
 assert(Vector3.new(7, 11, 15) // Vector3.new(3, 5, 7) == Vector3.new(2, 2, 2))
 assert(Vector3.new(3, 5, 7) // 2 == Vector3.new(1, 2, 3))
 
--- TODO: Vector math
+-- Vector math methods
+assert(Vector3.new(-1, -2, -3):Abs() == Vector3.new(1, 2, 3))
+assert(Vector3.new(-1.7, 2, -3):Sign() == Vector3.new(-1, 1, -1))
+assert(Vector3.new(-1.9, 2.1, 3.5):Ceil() == Vector3.new(-1, 3, 4))
+assert(Vector3.new(-1.1, 2.99, 3.5):Floor() == Vector3.new(-2, 2, 3))

--- a/tests/roblox/datatypes/Vector3.luau
+++ b/tests/roblox/datatypes/Vector3.luau
@@ -50,3 +50,5 @@ assert(Vector3.new(-1, -2, -3):Abs() == Vector3.new(1, 2, 3))
 assert(Vector3.new(-1.7, 2, -3):Sign() == Vector3.new(-1, 1, -1))
 assert(Vector3.new(-1.9, 2.1, 3.5):Ceil() == Vector3.new(-1, 3, 4))
 assert(Vector3.new(-1.1, 2.99, 3.5):Floor() == Vector3.new(-2, 2, 3))
+
+assert(Vector3.new(1, 2, 3):FuzzyEq(Vector3.new(1 - 1e-6, 2 + 1e-6, 3 + 1e-6), 1e-5))


### PR DESCRIPTION
Adds the following methods:

Vector2:
- Vector2:Angle(rhs)
- Vector2:FuzzyEq(rhs)
- Vector2:Abs()
- Vector2:Ceil()
- Vector2:Floor()
- Vector2:Sign()

Vector3:
- Vector3:Abs()
- Vector3:Ceil()
- Vector3:Floor()
- Vector3:Sign()

Doesn't implement optional `isSigned` boolean for `Vector2:Angle(rhs, isSigned)` Not totally sure if Option would be a good fit here. The optional axis vector is also missing on `Vector3:Angle(rhs, axis)`

Closes #214 