### PR TITLE
add disable-codegen option

### DIFF
--- a/crates/lune/src/cli/repl.rs
+++ b/crates/lune/src/cli/repl.rs
@@ -17,7 +17,11 @@ enum PromptState {
 
 /// Launch an interactive REPL (default)
 #[derive(Debug, Clone, Default, Parser)]
-pub struct ReplCommand {}
+pub struct ReplCommand {
+    /// If native codegen should be disabled. This is useful for benchmarking.
+    #[clap(long)]
+    disable_codegen: bool,
+}
 
 impl ReplCommand {
     pub async fn run(self) -> Result<ExitCode> {
@@ -38,7 +42,7 @@ impl ReplCommand {
         let mut prompt_state = PromptState::Regular;
         let mut source_code = String::new();
 
-        let mut lune_instance = Runtime::new();
+        let mut lune_instance = Runtime::new(!self.disable_codegen);
 
         loop {
             let prompt = match prompt_state {

--- a/crates/lune/src/cli/run.rs
+++ b/crates/lune/src/cli/run.rs
@@ -16,6 +16,9 @@ use super::utils::files::{discover_script_path_including_lune_dirs, strip_sheban
 pub struct RunCommand {
     /// Script name or full path to the file to run
     script_path: String,
+    /// If native codegen should be disabled. This is useful for benchmarking.
+    #[clap(long)]
+    disable_codegen: bool,
     /// Arguments to pass to the script, stored in process.args
     script_args: Vec<String>,
 }
@@ -41,7 +44,7 @@ impl RunCommand {
         };
 
         // Create a new lune runtime with all globals & run the script
-        let mut rt = Runtime::new().with_args(self.script_args);
+        let mut rt = Runtime::new(!self.disable_codegen).with_args(self.script_args);
 
         let result = rt
             .run(&script_display_name, strip_shebang(script_contents))

--- a/crates/lune/src/rt/runtime.rs
+++ b/crates/lune/src/rt/runtime.rs
@@ -27,8 +27,10 @@ self_cell! {
 }
 
 impl RuntimeInner {
-    fn create() -> LuaResult<Self> {
+    fn create(codegen: bool) -> LuaResult<Self> {
         let lua = Rc::new(Lua::new());
+
+        lua.enable_jit(codegen);
 
         lua.set_app_data(Rc::downgrade(&lua));
         lua.set_app_data(Vec::<String>::new());
@@ -110,9 +112,9 @@ impl Runtime {
     */
     #[must_use]
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new(codegen: bool) -> Self {
         Self {
-            inner: RuntimeInner::create().expect("Failed to create runtime"),
+            inner: RuntimeInner::create(codegen).expect("Failed to create runtime"),
         }
     }
 

--- a/crates/lune/src/standalone/mod.rs
+++ b/crates/lune/src/standalone/mod.rs
@@ -29,7 +29,7 @@ pub async fn run(patched_bin: impl AsRef<[u8]>) -> Result<ExitCode> {
     let args = env::args().skip(1).collect::<Vec<_>>();
     let meta = Metadata::from_bytes(patched_bin).expect("must be a standalone binary");
 
-    let mut rt = Runtime::new().with_args(args);
+    let mut rt = Runtime::new(true).with_args(args);
 
     let result = rt.run("STANDALONE", meta.bytecode).await;
 

--- a/crates/lune/src/tests.rs
+++ b/crates/lune/src/tests.rs
@@ -31,7 +31,7 @@ macro_rules! create_tests {
             // The rest of the test logic can continue as normal
             let full_name = format!("{}/tests/{}.luau", workspace_dir.display(), $value);
             let script = read_to_string(&full_name).await?;
-            let mut lune = Runtime::new().with_args(
+            let mut lune = Runtime::new(true).with_args(
                 ARGS
                     .clone()
                     .iter()


### PR DESCRIPTION
This adds a `disable-codegen` option to `lune run` and `lune repl`. This is useful for benchmarking projects both with and without codegen.