### PR TITLE
`IsA`, `ClassName` & `Parent` should work if an instance is already destroyed

### DIFF
--- a/crates/lune-roblox/src/instance/mod.rs
+++ b/crates/lune-roblox/src/instance/mod.rs
@@ -302,10 +302,7 @@ impl Instance {
     pub fn get_parent(&self) -> Option<Instance> {
         let dom = INTERNAL_DOM.lock().expect("Failed to lock document");
 
-        let parent_ref = dom
-            .get_by_ref(self.dom_ref)
-            .expect("Failed to find instance in document")
-            .parent();
+        let parent_ref = dom.get_by_ref(self.dom_ref)?.parent();
 
         if parent_ref == dom.root_ref() {
             None

--- a/tests/roblox/instance/methods/ClearAllChildren.luau
+++ b/tests/roblox/instance/methods/ClearAllChildren.luau
@@ -20,14 +20,10 @@ assert(not pcall(function()
 	return child1.Name
 end))
 
-assert(not pcall(function()
-	return child1.Parent
-end))
+assert(not child1.Parent)
 
 assert(not pcall(function()
 	return child2.Name
 end))
 
-assert(not pcall(function()
-	return child2.Parent
-end))
+assert(not child2.Parent)

--- a/tests/roblox/instance/methods/Destroy.luau
+++ b/tests/roblox/instance/methods/Destroy.luau
@@ -14,22 +14,16 @@ assert(not pcall(function()
 	return root.Name
 end))
 
-assert(not pcall(function()
-	return root.Parent
-end))
+assert(not root.Parent)
 
 assert(not pcall(function()
 	return child.Name
 end))
 
-assert(not pcall(function()
-	return child.Parent
-end))
+assert(not child.Parent)
 
 assert(not pcall(function()
 	return descendant.Name
 end))
 
-assert(not pcall(function()
-	return descendant.Parent
-end))
+assert(not descendant.Parent)


### PR DESCRIPTION
Initially from how the following errors:
```lua
print("Removing scripts...")
for _,v in place:GetService("Workspace"):GetDescendants() do
    if v:IsA("LuaSourceContainer") then
        v:Destroy()
    end
end
```

I tried to get `name` to work as well but I couldn't unless we add a field to the `Instance` struct.
I also tested the other methods to see if I could remove the `ensure_not_destroyed` requirement but I couldn't. It might be worth documenting that lune is different to Roblox where:
```lua
local p = Instance.new("Part");
p:Destroy();
print(p:GetChildren())
```
returns `{}`

This also introduces the fact that `v.Parent` can `= nil` which is useful in telling if an Instance is destroyed.