### PR TITLE
Add support for stdio.readLine

### DIFF
--- a/tests/stdio/readLine.luau
+++ b/tests/stdio/readLine.luau
@@ -1,0 +1,21 @@
+local stdio = require("@lune/stdio")
+
+local function linePrefix(prefix:string)
+    print("-------")
+    stdio.write(prefix)
+    local t = stdio.readLine()
+    print("-------")
+    return t
+end
+
+local function toEndPrefix(prefix:string)
+    print("-------")
+    stdio.write(prefix)
+    local t = stdio.readToEnd()
+    print("-------")
+    return t
+end
+
+print(linePrefix("READLINE> "))
+print(linePrefix("READLINE> "))
+print(toEndPrefix("READTOEND> "))

--- a/types/stdio.luau
+++ b/types/stdio.luau
@@ -59,8 +59,10 @@ end
 	stdio.write("All on the same line")
 	stdio.ewrite("\nAnd some error text, too")
 
-	-- Reading the entire input from stdin
-	local input = stdio.readToEnd()
+	-- Reading from stdin, either line-by-line or the entire input
+	local firstLine = stdio.readLine()
+	local secondLine = stdio.readLine()
+	local remaining = stdio.readToEnd()
 	```
 ]=]
 local stdio = {}
@@ -155,6 +157,18 @@ function stdio.ewrite(s: string) end
     @return The input from stdin
 ]=]
 function stdio.readToEnd(): string
+	return nil :: any
+end
+
+--[=[
+    @within Stdio
+    @tag must_use
+
+    Reads a single line from stdin.
+
+    @return The input from stdin
+]=]
+function stdio.readLine(): string
 	return nil :: any
 end
 


### PR DESCRIPTION
Implementes the `stdio.readLine` function in stdio using a Buffer.
Also changed `stdio.readToEnd` to use Buffers too.

In a nutshell, it uses a Mutex to mantain only one instance of the buffer for safety, there can only be a single STDIN by process anyhow. It does not block the entire tokio runtime neither "misses reads" (I did not get exactly what you've meant by this though).