### PR TITLE
Update rbx-dom dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,10 +2271,11 @@ dependencies = [
 
 [[package]]
 name = "rbx_binary"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b85057e8ff75a1ce99248200c4b3c7b481a3d52f921f1053ecd67921dcc7930"
+checksum = "9573fee5e073d7b303f475c285197fdc8179468de66ca60ee115a58fbac99296"
 dependencies = [
+ "ahash",
  "log",
  "lz4",
  "profiling",
@@ -2269,6 +2283,7 @@ dependencies = [
  "rbx_reflection",
  "rbx_reflection_database",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]
@@ -2288,19 +2303,21 @@ dependencies = [
 
 [[package]]
 name = "rbx_dom_weak"
-version = "2.9.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd2a17d09e46af0805f8b311a926402172b97e8d9388745c9adf8f448901841"
+checksum = "04425cf6e9376e5486f4fb35906c120d1b1b45618a490318cf563fab1fa230a9"
 dependencies = [
+ "ahash",
  "rbx_types",
  "serde",
+ "ustr",
 ]
 
 [[package]]
 name = "rbx_reflection"
-version = "4.7.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8118ac6021d700e8debe324af6b40ecfd2cef270a00247849dbdfeebb0802677"
+checksum = "1b6d0d62baa613556b058a5f94a53b01cf0ccde0ea327ce03056e335b982e77e"
 dependencies = [
  "rbx_types",
  "serde",
@@ -2309,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "rbx_reflection_database"
-version = "0.2.12+roblox-638"
+version = "1.0.1+roblox-666"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e29381d675420e841f8c02db5755cbb2545ed3e13f56c539546dc58702b512a"
+checksum = "1ea11f26cfddc57a136781baed2e68eda5a3aa0735152d1562d65b1909c8d65d"
 dependencies = [
  "lazy_static",
  "rbx_reflection",
@@ -2321,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "rbx_types"
-version = "1.10.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30f49b2a3bb667e4074ba73c2dfb8ca0873f610b448ccf318a240acfdec6c73"
+checksum = "78e4fdde46493def107e5f923d82e813dec9b3eef52c2f75fbad3a716023eda2"
 dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
@@ -2336,10 +2353,11 @@ dependencies = [
 
 [[package]]
 name = "rbx_xml"
-version = "0.13.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b14b3027bc9ccd82e2fc854c8bcd25ed58318e570c355bf2cf63df9cdbd5ba8"
+checksum = "bb623833c31cc43bbdaeb32f5e91db8ecd63fc46e438d0d268baf9e61539cf1c"
 dependencies = [
+ "ahash",
  "base64 0.13.1",
  "log",
  "rbx_dom_weak",
@@ -3482,6 +3500,19 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "ustr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b19e258aa08450f93369cf56dd78063586adf19e92a75b338a800f799a0208"
+dependencies = [
+ "ahash",
+ "byteorder 1.5.0",
+ "lazy_static",
+ "parking_lot",
+ "serde",
+]
 
 [[package]]
 name = "utf-8"

--- a/crates/lune-roblox/Cargo.toml
+++ b/crates/lune-roblox/Cargo.toml
@@ -20,10 +20,10 @@ rand = "0.8"
 thiserror = "1.0"
 once_cell = "1.17"
 
-rbx_binary = "0.7.7"
-rbx_dom_weak = "2.9.0"
-rbx_reflection = "4.7.0"
-rbx_reflection_database = "0.2.12"
-rbx_xml = "0.13.5"
+rbx_binary = "1.0.0"
+rbx_dom_weak = "3.0.0"
+rbx_reflection = "5.0.0"
+rbx_reflection_database = "1.0.0"
+rbx_xml = "1.0.0"
 
 lune-utils = { version = "0.1.3", path = "../lune-utils" }

--- a/crates/lune-roblox/src/datatypes/conversion.rs
+++ b/crates/lune-roblox/src/datatypes/conversion.rs
@@ -51,7 +51,7 @@ impl<'lua> DomValueToLua<'lua> for LuaValue<'lua> {
                 DomValue::Float32(n) => Ok(LuaValue::Number(*n as f64)),
                 DomValue::String(s) => Ok(LuaValue::String(lua.create_string(s)?)),
                 DomValue::BinaryString(s) => Ok(LuaValue::String(lua.create_string(s)?)),
-                DomValue::Content(s) => Ok(LuaValue::String(
+                DomValue::ContentId(s) => Ok(LuaValue::String(
                     lua.create_string(AsRef::<str>::as_ref(s))?,
                 )),
 

--- a/crates/lune-roblox/src/document/kind.rs
+++ b/crates/lune-roblox/src/document/kind.rs
@@ -65,7 +65,7 @@ impl DocumentKind {
         for child_ref in dom.root().children() {
             if let Some(child_inst) = dom.get_by_ref(*child_ref) {
                 has_top_level_child = true;
-                if class_is_a_service(&child_inst.class).unwrap_or(false) {
+                if class_is_a_service(child_inst.class).unwrap_or(false) {
                     has_top_level_service = true;
                     break;
                 }

--- a/crates/lune-roblox/src/document/postprocessing.rs
+++ b/crates/lune-roblox/src/document/postprocessing.rs
@@ -1,6 +1,6 @@
 use rbx_dom_weak::{
     types::{Ref as DomRef, VariantType as DomType},
-    Instance as DomInstance, WeakDom,
+    ustr, Instance as DomInstance, WeakDom,
 };
 
 use crate::shared::instance::class_is_a;
@@ -18,8 +18,8 @@ pub fn postprocess_dom_for_model(dom: &mut WeakDom) {
         remove_matching_prop(inst, DomType::UniqueId, "HistoryId");
         // Similar story with ScriptGuid - this is used
         // in the studio-only cloud script drafts feature
-        if class_is_a(&inst.class, "LuaSourceContainer").unwrap_or(false) {
-            inst.properties.remove("ScriptGuid");
+        if class_is_a(inst.class, "LuaSourceContainer").unwrap_or(false) {
+            inst.properties.remove(&ustr("ScriptGuid"));
         }
     });
 }
@@ -41,6 +41,7 @@ where
 }
 
 fn remove_matching_prop(inst: &mut DomInstance, ty: DomType, name: &'static str) {
+    let name = &ustr(name);
     if inst.properties.get(name).is_some_and(|u| u.ty() == ty) {
         inst.properties.remove(name);
     }

--- a/crates/lune-roblox/src/instance/data_model.rs
+++ b/crates/lune-roblox/src/instance/data_model.rs
@@ -48,7 +48,7 @@ fn data_model_get_service(_: &Lua, this: &Instance, service_name: String) -> Lua
         Ok(service)
     } else {
         let service = Instance::new_orphaned(service_name);
-        service.set_parent(Some(this.clone()));
+        service.set_parent(Some(*this));
         Ok(service)
     }
 }

--- a/crates/lune-roblox/src/shared/classes.rs
+++ b/crates/lune-roblox/src/shared/classes.rs
@@ -122,7 +122,7 @@ pub(crate) fn get_or_create_property_ref_instance(
         Ok(inst)
     } else {
         let inst = Instance::new_orphaned(class_name);
-        inst.set_parent(Some(this.clone()));
+        inst.set_parent(Some(*this));
         this.set_property(prop_name, DomValue::Ref(inst.dom_ref));
         Ok(inst)
     }

--- a/crates/lune-std-roblox/src/lib.rs
+++ b/crates/lune-std-roblox/src/lib.rs
@@ -77,7 +77,7 @@ async fn serialize_place<'lua>(
     lua: &'lua Lua,
     (data_model, as_xml): (LuaUserDataRef<'lua, Instance>, Option<bool>),
 ) -> LuaResult<LuaString<'lua>> {
-    let data_model = (*data_model).clone();
+    let data_model = *data_model;
     let fut = lua.spawn_blocking(move || {
         let doc = Document::from_data_model_instance(data_model)?;
         let bytes = doc.to_bytes_with_format(match as_xml {
@@ -94,7 +94,7 @@ async fn serialize_model<'lua>(
     lua: &'lua Lua,
     (instances, as_xml): (Vec<LuaUserDataRef<'lua, Instance>>, Option<bool>),
 ) -> LuaResult<LuaString<'lua>> {
-    let instances = instances.iter().map(|i| (*i).clone()).collect();
+    let instances = instances.iter().map(|i| **i).collect();
     let fut = lua.spawn_blocking(move || {
         let doc = Document::from_instance_array(instances)?;
         let bytes = doc.to_bytes_with_format(match as_xml {


### PR DESCRIPTION
Updates the Roblox library to use the latest rbx-dom release. Does not include `Content` or `Enum` attributes because this is essentially just noise on top of any other change.

This is a conservative change list; it doesn't modify the interface of anything even though there's a few signatures we could change to directly accept `Ustr` that might be cleaner. I don't think it's really worth doing, since it adds noise, but I can go through and change them if you want.