### PR TITLE
`RuntimeReturnValues` should derive `Debug`

### DIFF
--- a/crates/lune/src/rt/runtime.rs
+++ b/crates/lune/src/rt/runtime.rs
@@ -14,6 +14,7 @@ use super::{RuntimeError, RuntimeResult};
 /**
     Values returned by running a Lune runtime until completion.
 */
+#[derive(Debug)]
 #[non_exhaustive]
 pub struct RuntimeReturnValues {
     /// The exit code manually returned from the runtime, if any.


### PR DESCRIPTION
This allows me to nicely compare return values with `insta::assert_debug_snapshot!(result)`