### PR TITLE
Fix exit panics

### DIFF
--- a/crates/mlua-luau-scheduler/src/threads/map.rs
+++ b/crates/mlua-luau-scheduler/src/threads/map.rs
@@ -54,16 +54,12 @@ impl ThreadMap {
     }
 
     #[inline(always)]
-    pub async fn listen(&self, id: ThreadId) {
-        if let Some(listener) = {
-            let inner = self.inner.borrow();
-            let tracker = inner.get(&id);
-            tracker.map(|t| t.event.listen())
-        } {
-            listener.await;
-        } else {
-            panic!("Thread must be tracked");
-        }
+    pub fn listen(&self, id: ThreadId) -> impl Future<Output = ()> + use<> {
+        let inner = self.inner.borrow();
+        let tracker = inner.get(&id);
+        tracker
+            .map(|t| t.event.listen())
+            .expect("Thread must be tracked")
     }
 
     #[inline(always)]

--- a/crates/mlua-luau-scheduler/src/traits.rs
+++ b/crates/mlua-luau-scheduler/src/traits.rs
@@ -326,10 +326,9 @@ impl LuaSchedulerExt for Lua {
     }
 
     fn wait_for_thread(&self, id: ThreadId) -> impl Future<Output = ()> {
-        let map = self
-            .app_data_ref::<ThreadMap>()
-            .expect("lua threads results can only be retrieved from within an active scheduler");
-        async move { map.listen(id).await }
+        self.app_data_ref::<ThreadMap>()
+            .expect("lua threads results can only be retrieved from within an active scheduler")
+            .listen(id)
     }
 }
 


### PR DESCRIPTION
Fixes an issue that causes `process.exit` to panic with "cannot mutably borrow app data container" when called inside of a required module, or within the `net.serve` handler.

This was caused by `LuaSchedulerExt::wait_for_thread` holding a reference to the `ThreadMap` inside of the returned future. I've solved this by not having `ThreadMap::listen` be an async function, and directly returning a future which does not borrow `self`.