### PR TITLE
fix(process): exec not reading until child exits

### DIFF
--- a/crates/lune-std-process/src/exec/wait_for_child.rs
+++ b/crates/lune-std-process/src/exec/wait_for_child.rs
@@ -5,6 +5,7 @@ use mlua::prelude::*;
 use async_process::Child;
 use blocking::Unblock;
 use futures_lite::{io, prelude::*};
+use futures_util::try_join;
 
 use super::tee_writer::AsyncTeeWriter;
 use crate::options::ProcessSpawnOptionsStdioKind;
@@ -57,17 +58,15 @@ pub(super) async fn wait_for_child(
     let stdout_opt = child.stdout.take();
     let stderr_opt = child.stderr.take();
 
-    let stdout_task = read_with_stdio_kind(stdout_opt, stdout_kind);
-    let stderr_task = read_with_stdio_kind(stderr_opt, stderr_kind);
-
-    let status = child.status().await.into_lua_err()?;
-
-    let stdout_buffer = stdout_task.await.into_lua_err()?;
-    let stderr_buffer = stderr_task.await.into_lua_err()?;
+    let (status, stdout, stderr) = try_join!(
+        async { child.status().await.into_lua_err() },
+        read_with_stdio_kind(stdout_opt, stdout_kind),
+        read_with_stdio_kind(stderr_opt, stderr_kind)
+    )?;
 
     Ok(WaitForChildResult {
         status,
-        stdout: stdout_buffer,
-        stderr: stderr_buffer,
+        stdout,
+        stderr,
     })
 }

--- a/crates/lune-std-process/src/exec/wait_for_child.rs
+++ b/crates/lune-std-process/src/exec/wait_for_child.rs
@@ -32,7 +32,7 @@ where
 
             let mut buffer = Vec::new();
 
-            read_from.read_to_end(&mut buffer).await.into_lua_err()?;
+            io::copy(&mut read_from, &mut buffer).await.into_lua_err()?;
 
             buffer
         }


### PR DESCRIPTION
Fixes a bug where `process.exec` does not begin reading until the child process exits. This causes processes that write a lot of data to stdout to be unable to write data once the pipe buffer has filled up, causing them to hang.
